### PR TITLE
use distro-sync instead of dnf update/upgrade

### DIFF
--- a/worker-openmandriva-cooker/Dockerfile
+++ b/worker-openmandriva-cooker/Dockerfile
@@ -1,7 +1,6 @@
 FROM openmandriva/cooker
 
-RUN dnf update --assumeyes
-RUN dnf upgrade --assumeyes
+RUN dnf distro-sync --assumeyes
 RUN dnf install --assumeyes \
     glibc gcc-c++ git gnutar make cmake glib gettext lsb-release rpmdevtools rpm-build \
     glibc-devel boost-devel dbus-devel protobuf-devel protobuf-compiler sqlite-devel libasound-devel pulseaudio-devel gnutls-devel lib64GL-devel \


### PR DESCRIPTION
OpenMandriva preferred way to update system is dnf distro-sync. This should be use to avoid package conflicts or various orphans, old/bad stuff inherited from urpmi mandrake/mandriva. Should fix https://github.com/OpenMandrivaAssociation/distribution/issues/2951